### PR TITLE
Avoid .npmrc to be copied into docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ tests
 *.log*
 .gitignore
 .gitlab-ci.yml
+.npmrc
 .nvmrc
 .yarn-integrity
 Dockerfile


### PR DESCRIPTION
.npmrc file could expose authentication tokens that leads to credential leaks